### PR TITLE
change result to results in invoke response

### DIFF
--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
@@ -119,8 +119,7 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
             	if (body.startsWith("{")) {
             		// interpret as a JSON map, should contain jobid
             		Map<String,Object> json=JSON.parse(body);
-
-            		jobID=json.get("jobid").toString();
+			jobID=(String) json.get("jobid");
             		if (jobID==null) throw new RemoteException("Invoke failed: no jobid in body: "+body);
             	} else {
             		// interpret as a raw job ID

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteAgent.java
@@ -119,7 +119,8 @@ public class RemoteAgent extends AAgent implements Invokable, MarketAgent {
             	if (body.startsWith("{")) {
             		// interpret as a JSON map, should contain jobid
             		Map<String,Object> json=JSON.parse(body);
-            		jobID=(String) json.get("jobid");
+
+            		jobID=json.get("jobid").toString();
             		if (jobID==null) throw new RemoteException("Invoke failed: no jobid in body: "+body);
             	} else {
             		// interpret as a raw job ID

--- a/src/main/java/sg/dex/starfish/impl/remote/RemoteJob.java
+++ b/src/main/java/sg/dex/starfish/impl/remote/RemoteJob.java
@@ -78,7 +78,7 @@ public class RemoteJob implements Job {
         }
 
         if (newStatus.equals(SUCCEEDED)) {
-        	Map<String, Object> res=(Map<String, Object>) response.get("result");
+        	Map<String, Object> res=(Map<String, Object>) response.get("results");
         	if (res == null) throw new RemoteException("No result map in job id " + jobID + " result: " + response);
             // store result and success status
         	result=res;


### PR DESCRIPTION
Two changes done:

- request `results` instead of `result` as described in DEP-6
- The jobid is already Long, so casting to String fails. Therefore use `Long.toString` instead.